### PR TITLE
feat: enable both user and system flatpak installs

### DIFF
--- a/tests/example-system.yml
+++ b/tests/example-system.yml
@@ -1,0 +1,65 @@
+title: uBlue First Boot
+properties:
+  mode: "run-on-change"
+actions:
+  pre:
+    - run: /full/path/to/bin --with --params
+    - run: /another/command run
+    - yafti.plugin.flatpak:
+        install: org.gnome.Calculator
+  post:
+    - run: /run/these/commands --after --all --screens
+screens:
+  first-screen:
+    source: yafti.screen.title
+    values:
+      title: "That was pretty cool"
+      icon: "/path/to/icon"
+      description: |
+        Time to play overwatch
+  can-we-modify-your-flatpaks:
+    source: yafti.screen.consent
+    values:
+      title: Welcome traveler
+      condition:
+        run: flatpak remotes --system | grep fedora
+      description: |
+        This tool modifies your flatpaks and flatpak sources. If you do not want to do this exit the installer.
+        For new users just do it (tm)
+      actions:
+        - run: flatpak remote-delete fedora --force
+        - run: flatpak remove --system --noninteractive --all
+  applications:
+    source: yafti.screen.package
+    values:
+      title: Package Installation
+      show_terminal: true
+      package_manager: yafti.plugin.flatpak
+      package_manager_args:
+        user: false
+        system: true
+      groups:
+        Core:
+          description: All the good stuff
+          packages:
+            - Calculator: org.gnome.Calculator
+            - Firefox: org.mozilla.firefox
+        Gaming:
+          description: GAMES GAMES GAMES
+          default: false
+          packages:
+            - Steam: com.valvesoftware.Steam
+            - Games: org.gnome.Games
+        Office:
+          description: All the work stuff
+          default: false
+          packages:
+            - LibreOffice: org.libreoffice.LibreOffice
+            - Calendar: org.gnome.Calendar
+  final-screen:
+    source: yafti.screen.title
+    values:
+      title: "All done"
+      icon: "/atph/to/icon"
+      description: |
+        Thanks for installing, join the community, next steps

--- a/tests/example-system.yml
+++ b/tests/example-system.yml
@@ -35,7 +35,7 @@ screens:
       title: Package Installation
       show_terminal: true
       package_manager: yafti.plugin.flatpak
-      package_manager_args:
+      package_manager_defaults:
         user: false
         system: true
       groups:
@@ -43,7 +43,10 @@ screens:
           description: All the good stuff
           packages:
             - Calculator: org.gnome.Calculator
-            - Firefox: org.mozilla.firefox
+            - Firefox:
+                package: org.mozilla.firefox
+                system: false
+                user: true
         Gaming:
           description: GAMES GAMES GAMES
           default: false

--- a/tests/test_screen_package_utils.py
+++ b/tests/test_screen_package_utils.py
@@ -7,7 +7,13 @@ def test_parse_packages_groups():
             "description": "hello world",
             "packages": [
                 {"Calculator": "org.gnome.Calculator"},
-                {"Firefox": "org.mozilla.firefox"},
+                {
+                    "Firefox": {
+                        "package": "org.mozilla.firefox",
+                        "system": True,
+                        "user": False,
+                    },
+                },
             ],
         },
         "Gaming": {
@@ -23,7 +29,7 @@ def test_parse_packages_groups():
     expected = {
         "group:Core": True,
         "pkg:org.gnome.Calculator": True,
-        "pkg:org.mozilla.firefox": True,
+        'pkg:{"package": "org.mozilla.firefox", "system": true, "user": false}': True,
         "group:Gaming": True,
         "pkg:com.valvesoftware.Steam": True,
         "pkg:org.gnome.Games": True,

--- a/yafti/plugin/flatpak.py
+++ b/yafti/plugin/flatpak.py
@@ -150,7 +150,7 @@ class Flatpak(Run):
 
     async def install(
         self,
-        pkg: str,
+        package: str,
         user: bool = True,
         system: bool = False,
         assumeyes: bool = True,
@@ -161,7 +161,7 @@ class Flatpak(Run):
         """Install flatpak package on the host system
 
         Args:
-          pkg: Name of the flatpak package to install
+          package: Name of the flatpak package to install
           user: Install on the user installation
           system: Install on the system-wide installation
           assumeyes:
@@ -182,12 +182,12 @@ class Flatpak(Run):
         )
         cmd = [self.bin, "install"]
         cmd.extend(args)
-        cmd.append(pkg)
+        cmd.append(package)
         return await self.exec(" ".join(cmd))
 
     async def remove(
         self,
-        pkg: str,
+        package: str,
         user: bool = False,
         system: bool = True,
         force: bool = False,
@@ -199,7 +199,7 @@ class Flatpak(Run):
         )
         cmd = [self.bin, "remove"]
         cmd.extend(args)
-        cmd.append(pkg)
+        cmd.append(package)
         return self.exec(cmd)
 
     def ls(self) -> list[ApplicationDetail]:
@@ -214,10 +214,10 @@ class Flatpak(Run):
         # TODO: when a string is passed, make sure it maps to the "pkg" key.
         if params.install:
             if isinstance(params.install, str):
-                params.install = {"pkg": params.install}
+                params.install = {"package": params.install}
             r = asyncio.ensure_future(self.install(**params.install))
         else:
             if isinstance(params.remove, str):
-                params.remove = {"pkg": params.remove}
+                params.remove = {"package": params.remove}
             r = asyncio.ensure_future(self.remove(**params.install))
         return YaftiPluginReturn(output=r.stdout, errors=r.stderr, code=r.returncode)

--- a/yafti/screen/package/models.py
+++ b/yafti/screen/package/models.py
@@ -2,7 +2,7 @@ from pydantic import BaseModel
 
 
 class PackageConfig(BaseModel):
-    __root__: dict[str, str]
+    __root__: dict[str, str | dict]
 
 
 class PackageGroupConfigDetails(BaseModel):

--- a/yafti/screen/package/screen/install.py
+++ b/yafti/screen/package/screen/install.py
@@ -1,4 +1,5 @@
 import asyncio
+
 from gi.repository import Gtk
 
 import yafti.share

--- a/yafti/screen/package/screen/install.py
+++ b/yafti/screen/package/screen/install.py
@@ -72,17 +72,20 @@ class PackageInstallScreen(YaftiScreen, Gtk.Box):
 
     class Config(YaftiScreenConfig):
         package_manager: str = "yafti.plugin.flatpak"
+        package_manager_args: dict = {"user": True, "system": False}
 
     def __init__(
         self,
         title: str = "Package Installation",
         package_manager: str = "yafti.plugin.flatpak",
+        package_manager_args: dict = {"user": True, "system": False},
         **kwargs,
     ):
         super().__init__(**kwargs)
         from yafti.registry import PLUGINS
 
         self.package_manager = PLUGINS.get(package_manager)
+        self.package_manager_args = package_manager_args
         self.btn_console.connect("clicked", self.toggle_console)
 
     async def on_activate(self):
@@ -118,7 +121,7 @@ class PackageInstallScreen(YaftiScreen, Gtk.Box):
         yafti.share.BTN_NEXT.set_label("Installing...")
         yafti.share.BTN_BACK.set_visible(False)
         for idx, pkg in enumerate(packages):
-            r = await self.package_manager.install(pkg)
+            r = await self.package_manager.install(pkg, **self.package_manager_args)
             self.console.stdout(r.stdout)
             self.console.stderr(r.stderr)
             self.pulse = False

--- a/yafti/screen/package/screen/install.py
+++ b/yafti/screen/package/screen/install.py
@@ -1,10 +1,13 @@
 import asyncio
+import json
 
 from gi.repository import Gtk
+from typing import Optional
 
 import yafti.share
 from yafti import events
-from yafti.abc import YaftiScreen, YaftiScreenConfig
+from yafti import log
+from yafti.abc import YaftiScreen
 from yafti.screen.console import ConsoleScreen
 from yafti.screen.package.state import STATE
 
@@ -71,22 +74,18 @@ class PackageInstallScreen(YaftiScreen, Gtk.Box):
     already_run = False
     pulse = True
 
-    class Config(YaftiScreenConfig):
-        package_manager: str = "yafti.plugin.flatpak"
-        package_manager_args: dict = {"user": True, "system": False}
-
     def __init__(
         self,
         title: str = "Package Installation",
         package_manager: str = "yafti.plugin.flatpak",
-        package_manager_args: dict = {"user": True, "system": False},
+        package_manager_defaults: Optional[dict] = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
         from yafti.registry import PLUGINS
 
         self.package_manager = PLUGINS.get(package_manager)
-        self.package_manager_args = package_manager_args
+        self.package_manager_defaults = package_manager_defaults or {}
         self.btn_console.connect("clicked", self.toggle_console)
 
     async def on_activate(self):
@@ -117,14 +116,26 @@ class PackageInstallScreen(YaftiScreen, Gtk.Box):
         asyncio.create_task(self.do_pulse())
         return self.install(packages)
 
+    def run_package_manager(self, packge_config):
+        try:
+            config = json.loads(packge_config)
+        except json.decoder.JSONDecodeError as e:
+            log.debug("could not parse", config=packge_config, e=e)
+            config = {"package": packge_config}
+
+        log.debug("parsed packages config", config=config)
+        opts = self.package_manager_defaults.copy()
+        opts.update(config)
+        return self.package_manager.install(**opts)
+
     async def install(self, packages: list):
         total = len(packages)
         yafti.share.BTN_NEXT.set_label("Installing...")
         yafti.share.BTN_BACK.set_visible(False)
         for idx, pkg in enumerate(packages):
-            r = await self.package_manager.install(pkg, **self.package_manager_args)
-            self.console.stdout(r.stdout)
-            self.console.stderr(r.stderr)
+            results = await self.run_package_manager(pkg)
+            self.console.stdout(results.stdout)
+            self.console.stderr(results.stderr)
             self.pulse = False
             self.pkg_progress.set_fraction((idx + 1) / total)
 

--- a/yafti/screen/package/screen/package.py
+++ b/yafti/screen/package/screen/package.py
@@ -41,6 +41,7 @@ class PackageScreen(YaftiScreen, Adw.Bin):
     class Config(YaftiScreenConfig):
         show_terminal: bool = True
         package_manager: str
+        package_manager_args: dict = {}
         groups: Optional[PackageGroupConfig] = None
         packages: Optional[list[PackageConfig]] = None
 
@@ -48,6 +49,7 @@ class PackageScreen(YaftiScreen, Adw.Bin):
         self,
         title: str = "Package Installation",
         package_manager: str = "yafti.plugin.flatpak",
+        package_manager_args: dict = {},
         packages: list[PackageConfig] = None,
         groups: PackageGroupConfig = None,
         show_terminal: bool = True,
@@ -58,6 +60,7 @@ class PackageScreen(YaftiScreen, Adw.Bin):
         self.packages = groups or packages
         self.show_terminal = show_terminal
         self.package_manager = package_manager
+        self.package_manager_args = package_manager_args
         STATE.load(parse_packages(self.packages))
         self.pkg_carousel.connect("page-changed", self.changed)
         self.draw()
@@ -67,7 +70,7 @@ class PackageScreen(YaftiScreen, Adw.Bin):
             PackagePickerScreen(title=self.title, packages=self.packages)
         )
         self.pkg_carousel.append(
-            PackageInstallScreen(title=self.title, package_manager=self.package_manager)
+            PackageInstallScreen(title=self.title, package_manager=self.package_manager, package_manager_args=self.package_manager_args)
         )
 
     def on_activate(self):

--- a/yafti/screen/package/screen/package.py
+++ b/yafti/screen/package/screen/package.py
@@ -70,7 +70,11 @@ class PackageScreen(YaftiScreen, Adw.Bin):
             PackagePickerScreen(title=self.title, packages=self.packages)
         )
         self.pkg_carousel.append(
-            PackageInstallScreen(title=self.title, package_manager=self.package_manager, package_manager_args=self.package_manager_args)
+            PackageInstallScreen(
+                title=self.title,
+                package_manager=self.package_manager,
+                package_manager_args=self.package_manager_args,
+            )
         )
 
     def on_activate(self):

--- a/yafti/screen/package/screen/package.py
+++ b/yafti/screen/package/screen/package.py
@@ -41,18 +41,18 @@ class PackageScreen(YaftiScreen, Adw.Bin):
     class Config(YaftiScreenConfig):
         show_terminal: bool = True
         package_manager: str
-        package_manager_args: dict = {}
         groups: Optional[PackageGroupConfig] = None
         packages: Optional[list[PackageConfig]] = None
+        package_manager_defaults: Optional[dict] = None
 
     def __init__(
         self,
         title: str = "Package Installation",
         package_manager: str = "yafti.plugin.flatpak",
-        package_manager_args: dict = {},
         packages: list[PackageConfig] = None,
         groups: PackageGroupConfig = None,
         show_terminal: bool = True,
+        package_manager_defaults: Optional[dict] = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -60,7 +60,7 @@ class PackageScreen(YaftiScreen, Adw.Bin):
         self.packages = groups or packages
         self.show_terminal = show_terminal
         self.package_manager = package_manager
-        self.package_manager_args = package_manager_args
+        self.package_manager_defaults = package_manager_defaults
         STATE.load(parse_packages(self.packages))
         self.pkg_carousel.connect("page-changed", self.changed)
         self.draw()
@@ -73,7 +73,7 @@ class PackageScreen(YaftiScreen, Adw.Bin):
             PackageInstallScreen(
                 title=self.title,
                 package_manager=self.package_manager,
-                package_manager_args=self.package_manager_args,
+                package_manager_defaults=self.package_manager_defaults,
             )
         )
 

--- a/yafti/screen/package/screen/picker.py
+++ b/yafti/screen/package/screen/picker.py
@@ -1,4 +1,5 @@
 from functools import partial
+import json
 
 from gi.repository import Adw, Gtk
 from pydantic import BaseModel
@@ -79,6 +80,8 @@ class PackagePickerScreen(YaftiScreen, Adw.Bin):
                 d = self.packages.get(group)
                 for pkg in d.get("packages", []):
                     for pkg_name in pkg.values():
+                        if isinstance(pkg_name, dict):
+                            pkg_name = json.dumps(pkg_name)
                         STATE.set(f"pkg:{pkg_name}", value)
 
             state_set(name, None, details.get("default", True))
@@ -143,6 +146,8 @@ class PackagePickerScreen(YaftiScreen, Adw.Bin):
                     title=name,
                 )
                 _app_switcher = Gtk.Switch()
+                if isinstance(pkg, dict):
+                    pkg = json.dumps(pkg)
                 _app_switcher.set_active(STATE.get(f"pkg:{pkg}"))
                 _app_switcher.set_valign(Gtk.Align.CENTER)
 

--- a/yafti/screen/package/utils.py
+++ b/yafti/screen/package/utils.py
@@ -1,3 +1,6 @@
+import json
+
+
 def parse_packages(packages: dict | list) -> dict:
     output = {}
 
@@ -8,5 +11,8 @@ def parse_packages(packages: dict | list) -> dict:
         return output
 
     for pkgcfg in packages:
-        output.update({f"pkg:{package}": True for package in pkgcfg.values()})
+        for package in pkgcfg.values():
+            if isinstance(package, dict):
+                package = json.dumps(package)
+            output[f"pkg:{package}"] = True
     return output

--- a/yafti/screen/title.py
+++ b/yafti/screen/title.py
@@ -1,11 +1,11 @@
 import asyncio
 from functools import partial
-from typing import Optional, List
+from typing import List, Optional
 
 from gi.repository import Adw, Gtk
 
-from yafti.abc import YaftiScreen, YaftiScreenConfig
 from yafti import events
+from yafti.abc import YaftiScreen, YaftiScreenConfig
 from yafti.registry import PLUGINS
 
 _xml = """\


### PR DESCRIPTION
I love yafti but need the option to do flatpak system installs not only user installs.

This PR enables the package/install screens to use a new key in the config `package_manager_args` which itself is a `dict` of keys mapping to the respective package manager plugin's `install` method.

This allows a user of Yafti to enable system flatpak installs by adding the following to the yafti.yml:
```
      package_manager_args:
        user: false
        system: true
```
However, the solution is generic such that it could be used for other requirements.