### PR TITLE
feat: Allow run plugin to be used as a package manager

### DIFF
--- a/yafti/plugin/run.py
+++ b/yafti/plugin/run.py
@@ -89,6 +89,18 @@ class Run(YaftiPlugin):
             cmd, returncode=proc.returncode, stdout=stdout, stderr=stderr
         )
 
+    async def install(self, package: str) -> YaftiPluginReturn:
+        """Execute a command on the host system
+
+        Args:
+          package: The command to execute
+
+        Returns:
+          An object containing the stdout and stderr from the command
+        """
+        cmd = package
+        return await self.exec(cmd)
+
     @validate_arguments
     async def __call__(self, cmd: list[str] | str) -> YaftiPluginReturn:
         log.debug("run called", cmd=cmd)

--- a/yafti/plugin/run.py
+++ b/yafti/plugin/run.py
@@ -98,8 +98,7 @@ class Run(YaftiPlugin):
         Returns:
           An object containing the stdout and stderr from the command
         """
-        cmd = package
-        return await self.exec(cmd)
+        return await self.exec(package)
 
     @validate_arguments
     async def __call__(self, cmd: list[str] | str) -> YaftiPluginReturn:


### PR DESCRIPTION
This adds an install function to run that allows it to be used as a package manager on the package screen, providing categorizations of various commands

It does so by treating the passed command as a package from where the run plugin then executes it

Example:
```
  ...
  package_manager: yafti.plugin.run
    groups:
      Simple commands:
      - Hello World: echo 'Hello, World'
  ...
```
Result: 'Hello, World' is output in the console