### PR TITLE
feat: add save_state config property for changing when last-save state is recorded

### DIFF
--- a/tests/example-save-state.yml
+++ b/tests/example-save-state.yml
@@ -1,0 +1,63 @@
+title: uBlue First Boot
+properties:
+  mode: "run-on-change"
+  save_state: "last-screen"
+actions:
+  pre:
+    - run: /full/path/to/bin --with --params
+    - run: /another/command run
+    - yafti.plugin.flatpak:
+        install: org.gnome.Calculator
+  post:
+    - run: /run/these/commands --after --all --screens
+screens:
+  first-screen:
+    source: yafti.screen.title
+    values:
+      title: "That was pretty cool"
+      icon: "/path/to/icon"
+      description: |
+        Time to play overwatch
+  can-we-modify-your-flatpaks:
+    source: yafti.screen.consent
+    values:
+      title: Welcome traveler
+      condition:
+        run: flatpak remotes --system | grep fedora
+      description: |
+        This tool modifies your flatpaks and flatpak sources. If you do not want to do this exit the installer.
+        For new users just do it (tm)
+      actions:
+        - run: flatpak remote-delete fedora --force
+        - run: flatpak remove --system --noninteractive --all
+  applications:
+    source: yafti.screen.package
+    values:
+      title: Install flatpaks
+      show_terminal: true
+      package_manager: yafti.plugin.flatpak
+      groups:
+        Core:
+          description: All the good stuff
+          packages:
+            - Calculator: org.gnome.Calculator
+            - Firefox: org.mozilla.firefox
+        Gaming:
+          description: GAMES GAMES GAMES
+          default: false
+          packages:
+            - Steam: com.valvesoftware.Steam
+            - Games: org.gnome.Games
+        Office:
+          description: All the work stuff
+          default: false
+          packages:
+            - LibreOffice: org.libreoffice.LibreOffice
+            - Calendar: org.gnome.Calendar
+  final-screen:
+    source: yafti.screen.title
+    values:
+      title: "All done"
+      icon: "/atph/to/icon"
+      description: |
+        Thanks for installing, join the community, next steps

--- a/yafti/app.py
+++ b/yafti/app.py
@@ -21,7 +21,7 @@ import yaml
 from gi.repository import Adw
 from pathlib import Path
 
-from yafti.parser import Config, YaftiRunModes
+from yafti.parser import Config, YaftiRunModes, YaftSaveState
 from yafti.screen.window import Window
 
 
@@ -57,8 +57,8 @@ class Yafti(Adw.Application):
         super().run(*args, **kwargs)
 
     def do_activate(self):
-        win = Window(application=self)
-        win.present()
+        self._win = Window(application=self)
+        self._win.present()
         self.loop.run()
 
     @property
@@ -73,5 +73,14 @@ class Yafti(Adw.Application):
 
     def quit(self, *args, **kwargs):
         self.loop.stop()
-        self.sync_last_run()
+        if self.config.properties.save_state == YaftSaveState.always:
+            self.sync_last_run()
+
+        if (
+            self.config.properties.save_state == YaftSaveState.end
+            and self._win
+            and self._win.is_last_page
+        ):
+            self.sync_last_run()
+
         super().quit()

--- a/yafti/parser.py
+++ b/yafti/parser.py
@@ -38,9 +38,15 @@ class YaftiRunModes(str, Enum):
     disable = "disabled"
 
 
+class YaftSaveState(str, Enum):
+    always = "always"
+    end = "last-screen"
+
+
 class YaftiProperties(BaseModel):
     path: Optional[Path] = Path("~/.config/yafti/last-run")
     mode: YaftiRunModes = YaftiRunModes.changed
+    save_state: YaftSaveState = YaftSaveState.always
 
 
 class Config(BaseModel):

--- a/yafti/screen/window.py
+++ b/yafti/screen/window.py
@@ -136,6 +136,10 @@ class Window(Adw.ApplicationWindow):
         current_screen.deactivate()
         self.carousel.scroll_to(next_screen, animate)
 
+    @property
+    def is_last_page(self):
+        return self.idx + 1 >= self.carousel.get_n_pages()
+
     async def next(self, _) -> None:
         if self.idx + 1 >= self.carousel.get_n_pages():
             self.app.quit()


### PR DESCRIPTION
```yaml
title: uBlue First Boot
properties:
  mode: "run-on-change"
  save_state: "last-screen"
```

Options are `always` for backwards compat will save last-run state when the installer is closed. `last-screen` will only record last-run state when the last installer screen is reached.