### PR TITLE
fix:[#149] Remove quit option

### DIFF
--- a/yafti/screen/window.py
+++ b/yafti/screen/window.py
@@ -30,6 +30,7 @@ _xml = """\
                 <property name="orientation">horizontal</property>
               </object>
             </property>
+            <property name="show-end-title-buttons">False</property>
             <child type="start">
               <object class="GtkButton" id="btn_back">
                 <property name="label" translatable="yes">Back</property>


### PR DESCRIPTION
Add property `show-end-title-buttons`=`false` to AdwHeaderBar

Closes #149 