### PR TITLE
fix: RPM spec file misses `libadwaita` as an dependency

### DIFF
--- a/pkg/rpm.spec
+++ b/pkg/rpm.spec
@@ -10,6 +10,7 @@ Source0:        https://pypi.io/packages/source/y/%{modname}/%{modname}-%{versio
 
 BuildArch:      noarch
 
+Requires: libadwaita
 BuildRequires:  pyproject-rpm-macros
 
 %generate_buildrequires


### PR DESCRIPTION
So if some users try to install it on non-Gnome images, they would encounter non-working yafti.

Require `libadwaita` to fix this issue.

If you know which minimum version is required, I can edit that.

I can also add additional required dependencies, like `gtk4` if not pulled, or something else, just let me know